### PR TITLE
feat: add dedicated topics support for MQTT configuration

### DIFF
--- a/data/src/main/java/com/github/umercodez/sensorspot/data/gpsdataprovider/GpsDataProvider.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/gpsdataprovider/GpsDataProvider.kt
@@ -22,10 +22,13 @@ package com.github.umercodez.sensorspot.data.gpsdataprovider
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.json.JSONObject
 
 private val jsonConf = Json {
     encodeDefaults = true
 }
+
+
 
 @Serializable
 data class GpsData(
@@ -38,7 +41,19 @@ data class GpsData(
     val time: Long,
     val bearing: Float
 ){
-    fun toJson() =  jsonConf.encodeToString(this)
+    fun toJson(includeType: Boolean = true) :String {
+        val json = mapOf(
+            "type" to if (includeType) type else null,
+            "latitude" to latitude,
+            "longitude" to longitude,
+            "altitude" to altitude,
+            "accuracy" to accuracy,
+            "speed" to speed,
+            "time" to time,
+            "bearing" to bearing
+        ).filterValues { it != null }
+        return JSONObject(json).toString()
+    }
 }
 
 interface GpsDataProvider {

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/repositories/settings/Settings.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/repositories/settings/Settings.kt
@@ -29,6 +29,7 @@ data class Settings(
     val brokerPort: Int,
     val qos: Int,
     val topic: String,
+    val dedicatedTopics: Boolean,
     val connectionTimeoutSecs: Int,
     val useCredentials: Boolean,
     val userName: String,

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/repositories/settings/SettingsRepositoryImp.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/repositories/settings/SettingsRepositoryImp.kt
@@ -53,6 +53,7 @@ class SettingsRepositoryImp(
         val USE_CREDENTIALS = booleanPreferencesKey("use_credentials")
         val QOS = intPreferencesKey("qos")
         val TOPIC = stringPreferencesKey("topic")
+        val DEDICATED_TOPICS = booleanPreferencesKey("dedicated_topics")
         val CONNECTION_TIMEOUT_SECS = intPreferencesKey("connection_timeout_secs")
         val SENSOR_SAMPLING_RATE = intPreferencesKey("sensor_sampling_rate")
     }
@@ -69,6 +70,7 @@ class SettingsRepositoryImp(
                 useCredentials = pref[Key.USE_CREDENTIALS] ?: MqttConfigDefaults.USE_CREDENTIALS,
                 qos = pref[Key.QOS] ?: MqttConfigDefaults.QOS,
                 topic = pref[Key.TOPIC] ?: MqttConfigDefaults.TOPIC,
+                dedicatedTopics = pref[Key.DEDICATED_TOPICS] ?: MqttConfigDefaults.DEDICATED_TOPICS,
                 connectionTimeoutSecs = pref[Key.CONNECTION_TIMEOUT_SECS]
                     ?: MqttConfigDefaults.CONNECTION_TIMEOUT_SECS,
                 sensorSamplingRate = pref[Key.SENSOR_SAMPLING_RATE]
@@ -94,6 +96,7 @@ class SettingsRepositoryImp(
             pref[Key.USE_CREDENTIALS] = settings.useCredentials
             pref[Key.QOS] = settings.qos
             pref[Key.TOPIC] = settings.topic
+            pref[Key.DEDICATED_TOPICS] = settings.dedicatedTopics
             pref[Key.CONNECTION_TIMEOUT_SECS] = settings.connectionTimeoutSecs
         }
 

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensoreventprovider/SensorEventProvider.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensoreventprovider/SensorEventProvider.kt
@@ -20,7 +20,7 @@ package com.github.umercodez.sensorspot.data.sensoreventprovider
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import org.json.JSONObject
 
 @Serializable
 data class SensorEvent(
@@ -28,7 +28,14 @@ data class SensorEvent(
     val values: List<Float>,
     val timestamp: Long
 ){
-    fun toJson() = Json.encodeToString(this)
+    fun toJson(includeType: Boolean = true): String {
+        val json = mapOf(
+            "type" to if (includeType) type else null,
+            "values" to values,
+            "timestamp" to timestamp
+        ).filterValues { it != null }
+        return JSONObject(json).toString()
+    }
 }
 interface SensorEventProvider {
     val events: Flow<SensorEvent>

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensoreventprovider/SensorEventProvider.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensoreventprovider/SensorEventProvider.kt
@@ -19,10 +19,9 @@
 package com.github.umercodez.sensorspot.data.sensoreventprovider
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.serialization.Serializable
 import org.json.JSONObject
 
-@Serializable
+
 data class SensorEvent(
     val type: String,
     val values: List<Float>,

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/MqttConfig.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/MqttConfig.kt
@@ -26,6 +26,7 @@ object MqttConfigDefaults{
     const val BROKER_PORT = 1883
     const val QOS = 0
     const val TOPIC = "android/sensor"
+    const val DEDICATED_TOPICS = false
     const val CONNECTION_TIMEOUT_SECS = 5
     const val USE_CREDENTIALS = false
     const val USER_NAME = ""
@@ -40,6 +41,7 @@ data class MqttConfig(
     val brokerPort: Int = MqttConfigDefaults.BROKER_PORT,
     val qos: Int = MqttConfigDefaults.QOS,
     val topic: String = MqttConfigDefaults.TOPIC,
+    val dedicatedTopics: Boolean = MqttConfigDefaults.DEDICATED_TOPICS,
     val connectionTimeoutSecs: Int = MqttConfigDefaults.CONNECTION_TIMEOUT_SECS,
     val useCredentials: Boolean = MqttConfigDefaults.USE_CREDENTIALS,
     val userName: String = MqttConfigDefaults.USER_NAME,
@@ -54,6 +56,7 @@ data class MqttConfig(
                 brokerPort = settings.brokerPort,
                 qos = settings.qos,
                 topic = settings.topic,
+                dedicatedTopics = settings.dedicatedTopics,
                 connectionTimeoutSecs = settings.connectionTimeoutSecs,
                 useCredentials = settings.useCredentials,
                 userName = settings.userName,

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
@@ -43,6 +43,7 @@ import org.eclipse.paho.mqttv5.common.MqttMessage
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties
 import java.net.SocketTimeoutException
 import java.util.UUID
+import kotlin.text.split
 
 
 sealed interface MqttConnectionState{
@@ -84,7 +85,7 @@ class SensorPublisher(
 
     private fun getTopic(mqttConfig: MqttConfig, sensorType: String ) : String {
         return if(mqttConfig.dedicatedTopics){
-            "${mqttConfig.topic}/$sensorType"
+            "${mqttConfig.topic}/${sensorType.split('.').last()}"
         } else {
             mqttConfig.topic
         }

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
@@ -82,6 +82,13 @@ class SensorPublisher(
     val mqttConnectionState = _mqttConnectionState.asSharedFlow()
 
 
+    private fun getTopic(mqttConfig: MqttConfig, sensorType: String ) : String {
+        return if(mqttConfig.dedicatedTopics){
+            "${mqttConfig.topic}/$sensorType"
+        } else {
+            mqttConfig.topic
+        }
+    }
     suspend fun connectAndPublish(mqttConfig: MqttConfig) = withContext(ioDispatcher){
 
         scope.launch {
@@ -93,7 +100,7 @@ class SensorPublisher(
                         val message = MqttMessage(sensorEvent.toJson().toByteArray()).apply {
                             qos = mqttConfig.qos
                         }
-                        mqttAsyncClient?.publish(mqttConfig.topic, message)
+                        mqttAsyncClient?.publish(getTopic(mqttConfig, sensorEvent.type), message)
                     }
 
                 } catch (e: MqttException) {
@@ -111,7 +118,7 @@ class SensorPublisher(
                         val message = MqttMessage(gpsData.toJson().toByteArray()).apply {
                             qos = mqttConfig.qos
                         }
-                        mqttAsyncClient?.publish(mqttConfig.topic, message)
+                        mqttAsyncClient?.publish(getTopic(mqttConfig, gpsData.type), message)
                     }
 
                 } catch (e: MqttException) {

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
@@ -85,7 +85,7 @@ class SensorPublisher(
 
     private fun getTopic(mqttConfig: MqttConfig, sensorType: String ) : String {
         return if(mqttConfig.dedicatedTopics){
-            "${mqttConfig.topic}/${sensorType.split('.').last()}"
+            "${mqttConfig.topic}/${ if (sensorType.contains(".")) sensorType.split('.').last() else sensorType}"
         } else {
             mqttConfig.topic
         }

--- a/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
+++ b/data/src/main/java/com/github/umercodez/sensorspot/data/sensorpublisher/SensorPublisher.kt
@@ -97,7 +97,7 @@ class SensorPublisher(
                 try {
 
                     if(mqttAsyncClient?.isConnected == true) {
-                        val message = MqttMessage(sensorEvent.toJson().toByteArray()).apply {
+                        val message = MqttMessage(sensorEvent.toJson(!mqttConfig.dedicatedTopics).toByteArray()).apply {
                             qos = mqttConfig.qos
                         }
                         mqttAsyncClient?.publish(getTopic(mqttConfig, sensorEvent.type), message)
@@ -115,7 +115,7 @@ class SensorPublisher(
                 try {
 
                     if(mqttAsyncClient?.isConnected == true) {
-                        val message = MqttMessage(gpsData.toJson().toByteArray()).apply {
+                        val message = MqttMessage(gpsData.toJson(!mqttConfig.dedicatedTopics).toByteArray()).apply {
                             qos = mqttConfig.qos
                         }
                         mqttAsyncClient?.publish(getTopic(mqttConfig, gpsData.type), message)

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorScreenViewModel.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorScreenViewModel.kt
@@ -64,7 +64,10 @@ class SensorScreenViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.settings.collect { settings ->
                 _uiState.update {
-                    it.copy(dedicatedTopics = settings.dedicatedTopics)
+                    it.copy(
+                        dedicatedTopics = settings.dedicatedTopics,
+                        mqttTopic = settings.topic
+                    )
                 }
             }
         }

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorScreenViewModel.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorScreenViewModel.kt
@@ -21,6 +21,7 @@ package com.github.umercodez.sensorspot.ui.screens.sensors
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.umercodez.sensorspot.data.repositories.settings.SettingsRepository
 import com.github.umercodez.sensorspot.data.repositories.settings.sensor.SensorsRepository
 import com.github.umercodez.sensorspot.data.utils.LocationPermissionUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +35,8 @@ import javax.inject.Inject
 @HiltViewModel
 class SensorScreenViewModel @Inject constructor(
     private val sensorsRepository: SensorsRepository,
-    private val locationPermissionUtil: LocationPermissionUtil
+    private val locationPermissionUtil: LocationPermissionUtil,
+    private val settingsRepository: SettingsRepository
 ): ViewModel(){
 
     private val _uiState = MutableStateFlow(SensorsScreenState())
@@ -57,7 +59,14 @@ class SensorScreenViewModel @Inject constructor(
             _uiState.update {
                 it.copy(locationPermissionGranted = locationPermissionUtil.isLocationPermissionGranted())
             }
+        }
 
+        viewModelScope.launch {
+            settingsRepository.settings.collect { settings ->
+                _uiState.update {
+                    it.copy(dedicatedTopics = settings.dedicatedTopics)
+                }
+            }
         }
 
     }

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreen.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreen.kt
@@ -80,6 +80,7 @@ fun SensorsScreen(
             SensorItem(
                 modifier = Modifier.animateItem(),
                 sensor = sensor,
+                dedicatedTopics = state.dedicatedTopics,
                 checked = state.sensorSelectionState[sensor] == true,
                 onCheckedChange = {
                     onEvent(SensorsScreenEvent.OnSensorItemCheckedChange(sensor, it))
@@ -89,6 +90,7 @@ fun SensorsScreen(
         item {
             GpsItem(
                 checked = state.gpsChecked,
+                dedicatedTopics = state.dedicatedTopics,
                 onCheckedChange = {
                     onEvent(SensorsScreenEvent.OnGpsItemCheckedChange(it))
                 },

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreen.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreen.kt
@@ -81,6 +81,7 @@ fun SensorsScreen(
                 modifier = Modifier.animateItem(),
                 sensor = sensor,
                 dedicatedTopics = state.dedicatedTopics,
+                mqttTopic = state.mqttTopic,
                 checked = state.sensorSelectionState[sensor] == true,
                 onCheckedChange = {
                     onEvent(SensorsScreenEvent.OnSensorItemCheckedChange(sensor, it))
@@ -91,6 +92,7 @@ fun SensorsScreen(
             GpsItem(
                 checked = state.gpsChecked,
                 dedicatedTopics = state.dedicatedTopics,
+                mqttTopic = state.mqttTopic,
                 onCheckedChange = {
                     onEvent(SensorsScreenEvent.OnGpsItemCheckedChange(it))
                 },

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreenState.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreenState.kt
@@ -28,5 +28,6 @@ data class SensorsScreenState(
     val allSensors: SnapshotStateList<DeviceSensor> = mutableStateListOf(),
     val sensorSelectionState: SnapshotStateMap<DeviceSensor, Boolean> = mutableStateMapOf(),
     val locationPermissionGranted: Boolean = false,
-    val gpsChecked: Boolean = false
+    val gpsChecked: Boolean = false,
+    val dedicatedTopics: Boolean = false
 )

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreenState.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/SensorsScreenState.kt
@@ -29,5 +29,6 @@ data class SensorsScreenState(
     val sensorSelectionState: SnapshotStateMap<DeviceSensor, Boolean> = mutableStateMapOf(),
     val locationPermissionGranted: Boolean = false,
     val gpsChecked: Boolean = false,
-    val dedicatedTopics: Boolean = false
+    val dedicatedTopics: Boolean = false,
+    val mqttTopic: String = "android/sensor",
 )

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/GpsItem.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/GpsItem.kt
@@ -25,6 +25,7 @@ import com.github.umercodez.sensorspot.ui.SensorSpotTheme
 @Composable
 fun GpsItem(
     checked: Boolean,
+    dedicatedTopics: Boolean = false,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     locationPermissionGranted: Boolean = false,
@@ -55,8 +56,9 @@ fun GpsItem(
             }
         },
         supportingContent = {
+            val prefix = if (dedicatedTopics) "topic = android/sensor/" else "type = "
             Text(
-                text = "type = android.gps",
+                text = prefix + "android.gps",
                 color = MaterialTheme.colorScheme.onSurface
             )
         },

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/GpsItem.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/GpsItem.kt
@@ -26,6 +26,7 @@ import com.github.umercodez.sensorspot.ui.SensorSpotTheme
 fun GpsItem(
     checked: Boolean,
     dedicatedTopics: Boolean = false,
+    mqttTopic: String = "android/sensor",
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     locationPermissionGranted: Boolean = false,
@@ -56,9 +57,8 @@ fun GpsItem(
             }
         },
         supportingContent = {
-            val prefix = if (dedicatedTopics) "topic = android/sensor/" else "type = "
             Text(
-                text = prefix + "android.gps",
+                text = if (dedicatedTopics) "topic = ${mqttTopic}/gps" else "type = android.gps",
                 color = MaterialTheme.colorScheme.onSurface
             )
         },

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
@@ -53,6 +53,7 @@ import com.github.umercodez.sensorspot.ui.SensorSpotTheme
 fun SensorItem(
     sensor: DeviceSensor,
     dedicatedTopics: Boolean = false,
+    mqttTopic: String = "android/sensor",
     modifier: Modifier = Modifier,
     checked: Boolean = false,
     onCheckedChange: (Boolean) -> Unit
@@ -68,9 +69,13 @@ fun SensorItem(
         ListItem(
             headlineContent = { Text(text = sensor.name) },
             supportingContent = {
-                val prefix = if (dedicatedTopics) "topic = android/sensor/" else "type = "
+                val subText = if (dedicatedTopics) {
+                    "topic = ${mqttTopic}/${sensor.stringType.split('.').last()}"
+                } else {
+                    "type = ${sensor.stringType}"
+                }
                 BasicText(
-                    text = "$prefix${sensor.stringType}",
+                    text = subText,
                     style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
@@ -70,7 +70,7 @@ fun SensorItem(
             headlineContent = { Text(text = sensor.name) },
             supportingContent = {
                 val subText = if (dedicatedTopics) {
-                    "topic = ${mqttTopic}/${sensor.stringType.split('.').last()}"
+                    "topic = ${mqttTopic}/${ if (sensor.stringType.contains(".")) sensor.stringType.split('.').last() else sensor.stringType}"
                 } else {
                     "type = ${sensor.stringType}"
                 }

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/sensors/components/SensorItem.kt
@@ -52,6 +52,7 @@ import com.github.umercodez.sensorspot.ui.SensorSpotTheme
 @Composable
 fun SensorItem(
     sensor: DeviceSensor,
+    dedicatedTopics: Boolean = false,
     modifier: Modifier = Modifier,
     checked: Boolean = false,
     onCheckedChange: (Boolean) -> Unit
@@ -67,8 +68,9 @@ fun SensorItem(
         ListItem(
             headlineContent = { Text(text = sensor.name) },
             supportingContent = {
+                val prefix = if (dedicatedTopics) "topic = android/sensor/" else "type = "
                 BasicText(
-                    text = "type = ${sensor.stringType}",
+                    text = "$prefix${sensor.stringType}",
                     style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreen.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreen.kt
@@ -96,6 +96,17 @@ fun SettingsScreen(
         )
 
         ListItem(
+            headlineContent = { Text("Dedicated topics") },
+            supportingContent = { Text("use different topic for each sensor") },
+            trailingContent = {
+                Switch(
+                    checked = state.mqttConfig.dedicatedTopics,
+                    onCheckedChange = { onEvent(SettingsScreenEvent.OnDedicatedTopicsChange(it)) }
+                )
+            }
+        )
+
+        ListItem(
             headlineContent = { Text("Qos") },
             trailingContent = {
                 SingleChoiceSegmentedButtonRow {

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreenEvent.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreenEvent.kt
@@ -22,6 +22,7 @@ sealed interface SettingsScreenEvent {
     data class OnBrokerAddressChange(val brokerIp: String) : SettingsScreenEvent
     data class OnBrokerPortChange(val brokerPort: Int) : SettingsScreenEvent
     data class OnTopicChange(val topic: String) : SettingsScreenEvent
+    data class OnDedicatedTopicsChange(val dedicatedTopics: Boolean) : SettingsScreenEvent
     data class OnQosChange(val qos: Int) : SettingsScreenEvent
     data class OnUseSSLChange(val useSSL: Boolean) : SettingsScreenEvent
     data class OnUseWebsocketChange(val useWebsocket: Boolean) : SettingsScreenEvent

--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreenViewModel.kt
@@ -86,6 +86,13 @@ class SettingsScreenViewModel @Inject constructor(
                     }
                 }
             }
+            is SettingsScreenEvent.OnDedicatedTopicsChange -> {
+                viewModelScope.launch {
+                    settingsRepository.updateSettings {
+                        it.copy(dedicatedTopics = event.dedicatedTopics)
+                    }
+                }
+            }
             is SettingsScreenEvent.OnUseCredentialsChange -> {
                 viewModelScope.launch {
                     settingsRepository.updateSettings {


### PR DESCRIPTION
Add the option to publish each sensor on a different MQTT topic.

Some MQTT Dashboard applications such as IoT MQTT Panel do not support to filter the data by the values inside the message and to work properly, they need that the data is published on different topics.

When the option is enabled, it will publish to `android/sensor/{sensorEvent.type}`. 
E.g.: The Magnetometer sensor will publish to `android/sensor/android.sensor.magnetic_field`

TODO: the Settings screenshot in the README.md should be updated.