### PR TITLE
fix: update onUpdateClick to handle topic changes

### DIFF
--- a/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreen.kt
+++ b/ui/src/main/java/com/github/umercodez/sensorspot/ui/screens/settings/SettingsScreen.kt
@@ -92,7 +92,7 @@ fun SettingsScreen(
             isError = { value ->
                 value.isEmpty()
             },
-            onUpdateClick = { onEvent(SettingsScreenEvent.OnBrokerPortChange(it.toInt())) },
+            onUpdateClick = { onEvent(SettingsScreenEvent.OnTopicChange(it)) }
         )
 
         ListItem(


### PR DESCRIPTION
Updates the `onUpdateClick` handler to trigger the `OnTopicChange` event with the new value, instead of incorrectly triggering the `OnBrokerPortChange` event with an integer conversion.